### PR TITLE
Bugfix: Disallow Exchange Rates between identical currencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ use rusty_money::Exchange;
 use rusty_money::ExchangeRate;
 use rust_decimal_macros::*;
 
-let rate = ExchangeRate::new(Currency::get(USD), Currency::get(EUR), dec!(1.1));
+let rate = ExchangeRate::new(Currency::get(USD), Currency::get(EUR), dec!(1.1)).unwrap();
 rate.convert(money!(1000, "USD")); // 1,100 EUR
 
 // ExchangeRate objects can be stored and retrieved from a central Exchange:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! use rusty_money::ExchangeRate;
 //! use rust_decimal_macros::*;
 //!
-//! let rate = ExchangeRate::new(Currency::get(USD), Currency::get(EUR), dec!(1.1));
+//! let rate = ExchangeRate::new(Currency::get(USD), Currency::get(EUR), dec!(1.1)).unwrap();
 //! rate.convert(money!(1000, "USD")); // 1,100 EUR
 //!
 //! // ExchangeRate objects can be stored and retrieved from a central Exchange:


### PR DESCRIPTION
Do not allow exchange rates to be created between the same currency