### PR TITLE
Fix BRL Iso code

### DIFF
--- a/src/currency/iso.rs
+++ b/src/currency/iso.rs
@@ -383,11 +383,11 @@ pub fn from_enum(code: &Iso) -> Currency {
         },
         BRL => Currency {
             exponent: 2,
-            iso_alpha_code: "BOB",
+            iso_alpha_code: "BRL",
             iso_numeric_code: "986",
             locale: EnUs,
             minor_denomination: 5,
-            name: "Bolivian Boliviano",
+            name: "Brazilian real",
             symbol: "R$",
             symbol_first: true,
         },


### PR DESCRIPTION
The iso_alpha_code and name for the BRL currency was wrong. Fixing as of
https://en.wikipedia.org/wiki/ISO_4217