### PR TITLE
Fix ISO alpha and numeric code definitions in Currency objects

### DIFF
--- a/src/currency/iso.rs
+++ b/src/currency/iso.rs
@@ -564,7 +564,7 @@ pub fn from_enum(code: &Iso) -> Currency {
         CZK => Currency {
             exponent: 2,
             iso_alpha_code: "CZK",
-            iso_numeric_code: "132",
+            iso_numeric_code: "203",
             locale: EnBy,
             minor_denomination: 100,
             name: "Czech Koruna",
@@ -793,7 +793,7 @@ pub fn from_enum(code: &Iso) -> Currency {
         },
         HUF => Currency {
             exponent: 0,
-            iso_alpha_code: "HTG",
+            iso_alpha_code: "HUF",
             iso_numeric_code: "348",
             locale: EnBy,
             minor_denomination: 5,
@@ -1883,7 +1883,7 @@ pub fn from_enum(code: &Iso) -> Currency {
         },
         ZMW => Currency {
             exponent: 2,
-            iso_alpha_code: "ZMK",
+            iso_alpha_code: "ZMW",
             iso_numeric_code: "967",
             locale: EnUs,
             minor_denomination: 5,
@@ -1891,5 +1891,31 @@ pub fn from_enum(code: &Iso) -> Currency {
             symbol: "K",
             symbol_first: true,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iso_enum_name_matches_currency_iso_alpha_code() {
+        for iso in ISO_CURRENCIES {
+            let iso_alpha_code = format!("{}", iso);
+            let currency = from_enum(iso);
+            assert_eq!(iso_alpha_code, currency.iso_alpha_code);
+        }
+    }
+
+    #[test]
+    fn no_duplicate_currency_numeric_iso_codes() {
+        let mut numeric_codes: Vec<_> = ISO_CURRENCIES
+            .iter()
+            .map(|iso| from_enum(iso).iso_numeric_code)
+            .collect();
+
+        numeric_codes.sort();
+        numeric_codes.dedup();
+        assert_eq!(ISO_CURRENCIES.len(), numeric_codes.len());
     }
 }


### PR DESCRIPTION
Hello,
while using this library I noticed that the `Currency::find()` function is returning an error for the HUF currency (`InvalidCurrency`). Investigating further, I found that the issue lies in the definitions of the ISO alpha codes in the `Currency` objects in the iso.rs file.  
Due to the way the lookup maps are populated in currency.rs (using the `iso_alpha_code` field as key) this also causes the function to return the wrong `Currency` object for HTG, since the values in the hash map get overridden due to the duplicate values.  
The PR also contains a fix for a similar copy-paste bug regarding the numeric codes as well as some tests to ensure those kind of bugs are caught before being merged. I put them in the same file, if you don't mind.