### PR TITLE
Doc: fix crate name in lib.rs documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rusty_money = { version = "0.4.1", features = ["iso", "crypto"] }
+//! rusty-money = { version = "0.4.1", features = ["iso", "crypto"] }
 //! ```
 //! The currency sets can then be used like this:
 //!


### PR DESCRIPTION
The name of the crate to add as dependency in the doc from `lib.rs` that can be found on <https://docs.rs/rusty-money/0.4.1/rusty_money/index.html> is `rusty_money` while the real crate name is `rusty-money`.

This can be confusing / cause surprises to people copy-ing it in their `Cargo.toml`.

This PR fixes this :)
