### PR TITLE
Doc: bump version references to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ implements popular cryptocurencies. `iso` is enabled by default, and you can add
 
 ```toml
 [dependencies]
-rusty-money = { version = "0.4.0", features = ["iso", "crypto"] }
+rusty-money = { version = "0.4.1", features = ["iso", "crypto"] }
 ```
 
 The currency sets can then be used like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rusty_money = { version = "0.4.0", features = ["iso", "crypto"] }
+//! rusty_money = { version = "0.4.1", features = ["iso", "crypto"] }
 //! ```
 //! The currency sets can then be used like this:
 //!


### PR DESCRIPTION
Version `0.4.1` seems to be officially out (at least if I believes crates.io and the badges!)

This PR bumps version references from `0.4.0` to `0.4.1` in both the README and the `lib.rs` doc.
