### PR TITLE
Update rust_decimal to 1.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ default=["iso"]
 iso = []
 crypto = []
 
-
 [dependencies]
 rust_decimal = { default-features = false, version = "1.22.0" }
+
+[dev-dependencies]
 rust_decimal_macros = "1.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ crypto = []
 
 
 [dependencies]
-rust_decimal = { default-features = false, version = "1.9.0" }
-rust_decimal_macros = "1.9.0"
+rust_decimal = { default-features = false, version = "1.22.0" }
+rust_decimal_macros = "1.22.0"

--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -25,10 +25,7 @@ impl<'a, T: FormattableCurrency> Exchange<'a, T> {
     /// Return the ExchangeRate given the currency pair.
     pub fn get_rate(&self, from: &T, to: &T) -> Option<ExchangeRate<'a, T>> {
         let key = Exchange::generate_key(from, to);
-        match self.map.get(&key) {
-            Some(v) => Some(*v),
-            None => None,
-        }
+        self.map.get(&key).copied()
     }
 
     fn generate_key(from: &T, to: &T) -> String {

--- a/src/money.rs
+++ b/src/money.rs
@@ -9,7 +9,6 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use std::str::FromStr;
 
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 
 /// Represents an amount of a given currency.
 ///
@@ -226,17 +225,17 @@ impl<'a, T: FormattableCurrency> Money<'a, T> {
 
     /// Returns true if amount == 0.
     pub fn is_zero(&self) -> bool {
-        self.amount == dec!(0.0)
+        self.amount == Decimal::ZERO
     }
 
     /// Returns true if amount > 0.
     pub fn is_positive(&self) -> bool {
-        self.amount.is_sign_positive() && self.amount != dec!(0.0)
+        self.amount.is_sign_positive() && self.amount != Decimal::ZERO
     }
 
     /// Returns true if amount < 0.
     pub fn is_negative(&self) -> bool {
-        self.amount.is_sign_negative() && self.amount != dec!(0.0)
+        self.amount.is_sign_negative() && self.amount != Decimal::ZERO
     }
 
     /// Divides money equally into n shares.
@@ -263,12 +262,12 @@ impl<'a, T: FormattableCurrency> Money<'a, T> {
             .collect();
 
         let mut remainder = self.amount;
-        let ratio_total: Decimal = ratios.iter().fold(dec!(0.0), |acc, x| acc + x);
+        let ratio_total: Decimal = ratios.iter().fold(Decimal::ZERO, |acc, x| acc + x);
 
         let mut allocations: Vec<Money<'a, T>> = Vec::new();
 
         for ratio in ratios {
-            if ratio <= dec!(0.0) {
+            if ratio <= Decimal::ZERO {
                 return Err(MoneyError::InvalidRatio);
             }
 
@@ -278,18 +277,18 @@ impl<'a, T: FormattableCurrency> Money<'a, T> {
             remainder -= share;
         }
 
-        if remainder < dec!(0.0) {
+        if remainder < Decimal::ZERO {
             panic!("Remainder was negative, should be 0 or positive");
         }
 
-        if remainder - remainder.floor() != dec!(0.0) {
+        if remainder - remainder.floor() != Decimal::ZERO {
             panic!("Remainder is not an integer, should be an integer");
         }
 
         let mut i: usize = 0;
-        while remainder > dec!(0.0) {
-            allocations[i].amount += dec!(1.0);
-            remainder -= dec!(1.0);
+        while remainder > Decimal::ZERO {
+            allocations[i].amount += Decimal::ONE;
+            remainder -= Decimal::ONE;
             i += 1;
         }
         Ok(allocations)

--- a/src/money.rs
+++ b/src/money.rs
@@ -2,12 +2,14 @@ use crate::currency::FormattableCurrency;
 use crate::format::{Formatter, Params, Position};
 use crate::locale::LocalFormat;
 use crate::MoneyError;
-use rust_decimal::Decimal;
-use rust_decimal_macros::*;
+
 use std::cmp::Ordering;
 use std::fmt;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use std::str::FromStr;
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 
 /// Represents an amount of a given currency.
 ///
@@ -181,14 +183,14 @@ impl<'a, T: FormattableCurrency> Money<'a, T> {
                 parsed_decimal += "0";
             }
         } else if amount_parts.len() == 2 {
-            i32::from_str(&amount_parts[1])?;
+            i32::from_str(amount_parts[1])?;
             parsed_decimal = parsed_decimal + "." + amount_parts[1];
         } else {
             return Err(MoneyError::InvalidAmount);
         }
 
         let decimal = Decimal::from_str(&parsed_decimal).unwrap();
-        Ok(Money::from_decimal(decimal, &currency))
+        Ok(Money::from_decimal(decimal, currency))
     }
 
     /// Creates a Money object given an integer and a currency reference.
@@ -300,13 +302,13 @@ impl<'a, T: FormattableCurrency> Money<'a, T> {
         money.amount = match strategy {
             Round::HalfDown => money
                 .amount
-                .round_dp_with_strategy(digits, rust_decimal::RoundingStrategy::RoundHalfDown),
+                .round_dp_with_strategy(digits, rust_decimal::RoundingStrategy::MidpointTowardZero),
             Round::HalfUp => money
                 .amount
-                .round_dp_with_strategy(digits, rust_decimal::RoundingStrategy::RoundHalfUp),
+                .round_dp_with_strategy(digits, rust_decimal::RoundingStrategy::MidpointAwayFromZero),
             Round::HalfEven => money
                 .amount
-                .round_dp_with_strategy(digits, rust_decimal::RoundingStrategy::BankersRounding),
+                .round_dp_with_strategy(digits, rust_decimal::RoundingStrategy::MidpointNearestEven),
         };
 
         money


### PR DESCRIPTION
By updating it should give you numerous performance improvements from string parsing through to operational efficiencies. It also leverages associated constants so you can remove the need for `rust_decimal_macros` from the core dependencies.

No pressure to merge - just saw it as an easy update!