### PR TITLE
fix: forward lifetime annotation to ExchangeRate in set_rate

### DIFF
--- a/src/exchange.rs
+++ b/src/exchange.rs
@@ -17,7 +17,7 @@ impl<'a, T: FormattableCurrency> Exchange<'a, T> {
     }
 
     /// Update an ExchangeRate or add it if does not exist.
-    pub fn set_rate(&mut self, rate: &'a ExchangeRate<T>) {
+    pub fn set_rate(&mut self, rate: &ExchangeRate<'a, T>) {
         let key = Exchange::generate_key(rate.from, rate.to);
         self.map.insert(key, *rate);
     }


### PR DESCRIPTION
Fixed an issue with the `Exchange::set_rate` function which specified that the passed in reference for the `ExchangeRate` needs to have the same lifetime (`'a`) as the `Exchange` instance. This is incorrect as the instance needs to have the same lifetime as the currencies stored inside its `ExchangeRate` map values (and not just this particular instance of `ExchangeRate` that was passed in). The change simply forwards the lifetime annotation to `ExchangeRate`.

This allows functions to create and return Exchanges that just use the static currencies like so:

```rust
fn get_exchange() -> Exchange<'static, Currency> {
    let mut exchange: Exchange<'static, Currency> = Exchange::new();
    let rate: ExchangeRate<'static, Currency> =
        ExchangeRate::new(iso::USD, iso::PKR, dec!(237)).unwrap();
    exchange.set_rate(&rate); // this line would previously not compile with "`rate` does not live long enough"
    exchange
}
```