### PR TITLE
Changed Singapore dollar sign to 'S$'

### DIFF
--- a/src/currency/iso_currencies.rs
+++ b/src/currency/iso_currencies.rs
@@ -1332,7 +1332,7 @@ pub mod iso {
             locale: EnUs,
             minor_units: 1,
             name: "Singapore Dollar",
-            symbol: "$",
+            symbol: "S$",
             symbol_first: true,
         },
         SHP : {


### PR DESCRIPTION
Hello :wave: 

I'm currently using the library, and I think I found a case where a currency symbol is ambiguous.

For Singapore currency sign, I think it can be changed from just `$` to `S$` ([wikipedia](https://en.wikipedia.org/wiki/Singapore_dollar)), since currently I'm supporting both the USD & SGD currency, and it's kinda confusing when both are displayed

The sign symbol seems to be outside of the scope of the ISO, so I'm guessing it's fine since there doesn't seem to be any standard for it