### PR TITLE
fix: Romanian currencies

### DIFF
--- a/src/currency/iso_currencies.rs
+++ b/src/currency/iso_currencies.rs
@@ -1242,7 +1242,17 @@ pub mod iso {
             locale: EnEu,
             minor_units: 1,
             name: "Romanian Leu",
-            symbol: "ر.ق",
+            symbol: "RON",
+            symbol_first: false,
+        },
+        ROL : {
+            exponent: 0,
+            iso_alpha_code: "ROL",
+            iso_numeric_code: "642",
+            locale: EnEu,
+            minor_units: 1,
+            name: "Romanian Leu",
+            symbol: "ROL",
             symbol_first: false,
         },
         RSD : {


### PR DESCRIPTION
Trying to address #62 and also add the second Romanian Leu currency which was used up till 2005 (ROL).

Not sure what the minor units should be set to. Please kindly review.