### PR TITLE
feat: impl neg for Money

### DIFF
--- a/src/money.rs
+++ b/src/money.rs
@@ -5,7 +5,7 @@ use crate::MoneyError;
 
 use std::cmp::Ordering;
 use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use std::str::FromStr;
 
 use rust_decimal::Decimal;
@@ -63,6 +63,17 @@ impl<'a, T: FormattableCurrency> SubAssign for Money<'a, T> {
             amount: self.amount - other.amount,
             currency: self.currency,
         };
+    }
+}
+
+impl<'a, T: FormattableCurrency> Neg for Money<'a, T> {
+    type Output = Money<'a, T>;
+
+    fn neg(self) -> Self::Output {
+        Money {
+            amount: -self.amount,
+            currency: self.currency,
+        }
     }
 }
 
@@ -645,6 +656,13 @@ mod tests {
         let mut money = Money::from_minor(100, test::USD);
         money /= Decimal::new(-2, 0);
         assert_eq!(Money::from_minor(-50, test::USD), money);
+    }
+
+    #[test]
+    fn money_negation() {
+        let money = Money::from_minor(100, test::USD);
+
+        assert_eq!(-money, Money::from_minor(-100, test::USD));
     }
 
     #[test]


### PR DESCRIPTION
Implement [Neg](https://doc.rust-lang.org/std/ops/trait.Neg.html) trait for `Money` to enable unary `-` operator -- it's fairly simple, and might come handy in some scenarios, e.g. tests.

For instance, to make my code more clear I used a helper method in my tests:
```rust
fn usd(major: i64) -> Money<'static, Currency> {
    use rusty_money::iso::USD;

    Money::from_major(major, USD)
}
```

Right now these assertions work fine:
```rust
assert_eq!(total, -1 * usd(10))
assert_eq!(total, usd(-10))
```
but I don't like neither. This feels more natural to me:
```rust
assert_eq!(total, -usd(10))
```