### PR TITLE
api exposing the currency names for quick import

### DIFF
--- a/src/currency/iso_currencies.rs
+++ b/src/currency/iso_currencies.rs
@@ -82,6 +82,9 @@ pub mod iso {
         };
       )+
 
+      // Api for all currency names
+      pub const CURRENCIES: &[&Currency] = &[$($currency),+];
+
       pub fn find(code: &str) -> Option<&'static Currency> {
         match code {
           $($alpha_code => (Some($currency)),)+


### PR DESCRIPTION
So I need names of the currencies for my autocomplete and this crate can simply expose it, but its not exposing it right now, so thats what this PR does.

NOTE: maybe dont make it const, but rather static?